### PR TITLE
add a note to use `contents: read` for checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ permissions:
   pull-requests: write
   issues: write
   checks: read
+  contents: read # useful if your workflows call actions/checkout@vX.X.X
 
 jobs:
   demo:


### PR DESCRIPTION
This permission is not required in _every_ usage of `github/command` but many folks use it in combination with workflows that checkout the repository. Adding it to the main readme makes sense.

related: https://github.com/github/command/issues/49