### PR TITLE
Remove maintain permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Advanced usage with some custom configuration:
     command: .restart # can be anything you want (example)
     reaction: "eyes"
     allowed_contexts: "pull_request,issue"
-    permissions: "maintain,admin"
+    permissions: "write,admin"
     allowlist: monalisa
 ```
 
@@ -190,7 +190,7 @@ As seen above, we have a single example step. Perhaps you would actually use a r
 | `success_reaction` | `true` | `+1` | The reaction to add to the comment that triggered the Action if its execution was successful |
 | `failure_reaction` | `true` | `-1` | The reaction to add to the comment that triggered the Action if its execution failed |
 | `allowed_contexts` | `true` | `pull_request` | A comma separated list of comment contexts that are allowed to trigger this IssueOps command. Pull requests and issues are the only currently supported contexts. To allow IssueOps commands to be invoked from both PRs and issues, set this option to the following: `"pull_request,issue"`. By default, the only place this Action will allow IssueOps commands from is pull requests |
-| `permissions` | `true` | `"write,maintain,admin"` | The allowed GitHub permissions an actor can have to invoke IssueOps commands |
+| `permissions` | `true` | `"write,admin"` | The allowed GitHub permissions an actor can have to invoke IssueOps commands |
 | `allow_drafts` | `true` | `"false"` | Whether or not to allow this IssueOps command to be run on draft pull requests |
 | `allow_forks` | `true` | `"false"` | Whether or not to allow this IssueOps command to be run on forked pull requests |
 | `skip_ci` | `true` | `"false"` | Whether or not to require passing CI checks before this IssueOps command can be run |

--- a/__tests__/functions/prechecks.test.js
+++ b/__tests__/functions/prechecks.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
   jest.spyOn(core, 'debug').mockImplementation(() => {})
   jest.spyOn(core, 'warning').mockImplementation(() => {})
   jest.spyOn(core, 'setOutput').mockImplementation(() => {})
-  process.env.INPUT_PERMISSIONS = 'admin,write,maintain'
+  process.env.INPUT_PERMISSIONS = 'admin,write'
 
   jest.spyOn(validPermissions, 'validPermissions').mockImplementation(() => {
     return true

--- a/__tests__/functions/valid-permissions.test.js
+++ b/__tests__/functions/valid-permissions.test.js
@@ -8,7 +8,7 @@ var context
 beforeEach(() => {
   jest.clearAllMocks()
   jest.spyOn(core, 'setOutput').mockImplementation(() => {})
-  process.env.INPUT_PERMISSIONS = 'write,maintain,admin'
+  process.env.INPUT_PERMISSIONS = 'write,admin'
 
   context = {
     actor: 'monalisa'
@@ -44,7 +44,7 @@ test('determines that a user has does not valid permissions to invoke the Action
     })
 
   expect(await validPermissions(octokit, context)).toEqual(
-    '👋 __monalisa__, seems as if you have not write/maintain/admin permissions in this repo, permissions: read'
+    '👋 __monalisa__, seems as if you have not write/admin permissions in this repo, permissions: read'
   )
   expect(setOutputMock).toHaveBeenCalledWith('actor', 'monalisa')
 })

--- a/action.yml
+++ b/action.yml
@@ -33,9 +33,9 @@ inputs:
     required: true
     default: "pull_request"
   permissions:
-    description: 'The allowed GitHub permissions an actor can have to invoke IssueOps commands - Example: "write,maintain,admin"'
+    description: 'The allowed GitHub permissions an actor can have to invoke IssueOps commands - Example: "write,admin"'
     required: true
-    default: "write,maintain,admin"
+    default: "write,admin"
   allow_drafts:
     description: 'Whether or not to allow this IssueOps command to be run on draft pull requests'
     required: true


### PR DESCRIPTION
There is no `maintain` permission on GitHub. Removing it from code base because it can bring confusion with `maintain` role.

Official documentation: https://docs.github.com/en/enterprise-cloud@latest/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user

```
Checks the repository permission of a collaborator. The possible repository permissions are admin, write, read, and none.

Note: The permission attribute provides the legacy base roles of admin, write, read, and none, where the maintain role is mapped to write and the triage role is mapped to read. To determine the role assigned to the collaborator, see the role_name attribute, which will provide the full role name, including custom roles. The permissions hash can also be used to determine which base level of access the collaborator has to the repository.
```


---

related: https://github.com/github/branch-deploy/pull/351