### PR TITLE
feat: validate GitHub App permissions via API and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ As seen above, we have a single example step. Perhaps you would actually use a r
 | `success_reaction` | `true` | `+1` | The reaction to add to the comment that triggered the Action if its execution was successful |
 | `failure_reaction` | `true` | `-1` | The reaction to add to the comment that triggered the Action if its execution failed |
 | `allowed_contexts` | `true` | `pull_request` | A comma separated list of comment contexts that are allowed to trigger this IssueOps command. Pull requests and issues are the only currently supported contexts. To allow IssueOps commands to be invoked from both PRs and issues, set this option to the following: `"pull_request,issue"`. By default, the only place this Action will allow IssueOps commands from is pull requests |
-| `permissions` | `true` | `"write,admin"` | The allowed GitHub permissions an actor can have to invoke IssueOps commands |
+| `permissions` | `true` | `"write,admin"` | The allowed GitHub permissions an actor can have to invoke IssueOps commands. Note that permission check for GitHub App ignores this and instead expects "issues" permission set to "write". |
 | `allow_drafts` | `true` | `"false"` | Whether or not to allow this IssueOps command to be run on draft pull requests |
 | `allow_forks` | `true` | `"false"` | Whether or not to allow this IssueOps command to be run on forked pull requests |
 | `skip_ci` | `true` | `"false"` | Whether or not to require passing CI checks before this IssueOps command can be run |

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: true
     default: "pull_request"
   permissions:
-    description: 'The allowed GitHub permissions an actor can have to invoke IssueOps commands - Example: "write,admin"'
+    description: 'The allowed GitHub permissions an actor can have to invoke IssueOps commands - Example: "write,admin". Permission check for GitHub App ignores this and instead expects "issues" permission set to "write".'
     required: true
     default: "write,admin"
   allow_drafts:
@@ -57,7 +57,7 @@ inputs:
     required: true
     default: "|"
   allowlist:
-    description: 'A comma separated list of GitHub usernames or teams that should be allowed to use the IssueOps commands configured in this Action. If unset, then all users meeting the "permissions" requirement will be able to run commands. Example: "monalisa,octocat,my-org/my-team"'
+    description: 'A comma separated list of GitHub usernames or teams that should be allowed to use the IssueOps commands configured in this Action. If unset, then all users meeting the "permissions" requirement will be able to run commands. Example: "monalisa,monalisa[bot],octocat,my-org/my-team"'
     required: false
     default: "false"
   allowlist_pat:


### PR DESCRIPTION
- Use `octokit.rest.users.getByUsername` to determine actor type (`User` or `Bot`)
- Fetch GitHub App installation details with `octokit.rest.apps.getRepoInstallation` for permission validation.
- Ensure GitHub Apps have `"issues"` permission set to `"write"` before allowing execution.
- Add test cases for GitHub App actors